### PR TITLE
feat: add CI/CD pipeline for Docker Hub deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,50 @@
+# Dependencies
 node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
 dist
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Database
 data
 *.db
 *.db-journal
 *.db-wal
 *.db-shm
+
+# Git
 .git
 .gitignore
+.gitattributes
+
+# GitHub Actions
+.github
+
+# Documentation
 *.md
-.env
-.env.local
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+
+# Docker files
+docker-compose*.yml
+Dockerfile
+.dockerignore
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+coverage
+.nyc_output

--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,0 +1,7 @@
+# Docker Hub Configuration
+# Replace with your Docker Hub username
+DOCKERHUB_USERNAME=your-dockerhub-username
+
+# Port Configuration
+# The port on your host machine where the app will be accessible
+PORT=3000

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,58 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/storynexus
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,209 @@
+# Deployment Guide
+
+This document explains how to deploy The Story Nexus using the CI/CD pipeline with Docker Hub.
+
+## Architecture Overview
+
+**Development**: Local build and run with `docker-compose.yml`
+**Production CI/CD**: GitHub Actions builds and pushes to Docker Hub
+**Deployment**: Third-party servers pull pre-built images from Docker Hub
+
+## Setup CI/CD Pipeline
+
+### 1. Docker Hub Setup
+
+Create a Docker Hub account at https://hub.docker.com if you don't have one.
+
+Create an access token:
+1. Go to Account Settings → Security → Access Tokens
+2. Click "New Access Token"
+3. Name it (e.g., "github-actions-storynexus")
+4. Copy the token (you won't see it again)
+
+### 2. GitHub Repository Secrets
+
+Add the following secrets to your GitHub repository:
+
+1. Go to repository Settings → Secrets and variables → Actions
+2. Add two new repository secrets:
+   - `DOCKERHUB_USERNAME`: Your Docker Hub username
+   - `DOCKERHUB_TOKEN`: The access token you created
+
+### 3. Trigger a Build
+
+The CI/CD pipeline automatically triggers on:
+- Push to `main` branch
+- Creating version tags (e.g., `v1.0.0`)
+- Manual workflow dispatch
+
+To create a tagged release:
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+This creates multiple image tags:
+- `latest` (main branch builds)
+- `v1.0.0` (semantic version)
+- `1.0` (major.minor)
+- `1` (major version)
+- `main-<git-sha>` (branch + commit SHA)
+
+## Deployment on Third-Party Server
+
+### Prerequisites
+
+- Docker and Docker Compose installed
+- Network access to Docker Hub
+
+### Deployment Steps
+
+1. **Copy deployment files to server**:
+```bash
+scp docker-compose.deploy.yml .env.deploy.example user@server:/opt/storynexus/
+```
+
+2. **SSH into server**:
+```bash
+ssh user@server
+cd /opt/storynexus
+```
+
+3. **Configure environment**:
+```bash
+cp .env.deploy.example .env
+nano .env
+```
+
+Edit `.env`:
+```bash
+DOCKERHUB_USERNAME=your-dockerhub-username
+PORT=3000
+```
+
+4. **Create data directory**:
+```bash
+mkdir -p data
+```
+
+5. **Pull and run**:
+```bash
+docker compose -f docker-compose.deploy.yml pull
+docker compose -f docker-compose.deploy.yml up -d
+```
+
+6. **Verify deployment**:
+```bash
+docker compose -f docker-compose.deploy.yml ps
+docker compose -f docker-compose.deploy.yml logs -f
+```
+
+Access the application at `http://server-ip:3000`
+
+### Update to New Version
+
+```bash
+docker compose -f docker-compose.deploy.yml pull
+docker compose -f docker-compose.deploy.yml up -d
+```
+
+The `up -d` command automatically recreates containers with the new image.
+
+### Use Specific Version
+
+Edit `docker-compose.deploy.yml` to pin a specific version:
+```yaml
+image: ${DOCKERHUB_USERNAME}/storynexus:v1.0.0
+```
+
+Then pull and restart:
+```bash
+docker compose -f docker-compose.deploy.yml up -d
+```
+
+## Local Development vs Production
+
+### Local Development
+Uses `docker-compose.yml` which builds from source:
+```bash
+docker compose up --build
+```
+
+### Production Deployment
+Uses `docker-compose.deploy.yml` which pulls pre-built images:
+```bash
+docker compose -f docker-compose.deploy.yml up -d
+```
+
+## Troubleshooting
+
+### Image Pull Failed
+- Verify Docker Hub username in `.env`
+- Check image exists: `docker search your-username/storynexus`
+- Ensure server has internet access
+
+### Container Won't Start
+```bash
+docker compose -f docker-compose.deploy.yml logs
+```
+
+### Permission Issues
+```bash
+sudo chown -R 1000:1000 data/
+```
+
+### Reset Database
+```bash
+docker compose -f docker-compose.deploy.yml down -v
+rm -rf data/*
+docker compose -f docker-compose.deploy.yml up -d
+```
+
+## Multi-Architecture Support
+
+Images are built for:
+- `linux/amd64` (Intel/AMD)
+- `linux/arm64` (Apple Silicon, ARM servers)
+
+Docker automatically pulls the correct architecture.
+
+## Security Considerations
+
+- Never commit `.env` files
+- Use Docker secrets for sensitive data in production
+- Keep Docker and Docker Compose updated
+- Run containers as non-root user (consider adding USER directive)
+- Use specific version tags in production, not `latest`
+
+## Monitoring
+
+Check container health:
+```bash
+docker compose -f docker-compose.deploy.yml ps
+```
+
+View logs:
+```bash
+docker compose -f docker-compose.deploy.yml logs -f storynexus
+```
+
+Check resource usage:
+```bash
+docker stats storynexus-app
+```
+
+## Backup
+
+Backup the data directory regularly:
+```bash
+tar -czf storynexus-backup-$(date +%Y%m%d).tar.gz data/
+```
+
+## Rollback
+
+To rollback to a previous version:
+```bash
+docker compose -f docker-compose.deploy.yml down
+# Edit docker-compose.deploy.yml to use previous version tag
+docker compose -f docker-compose.deploy.yml up -d
+```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ npm run db:migrate   # Apply migrations to database
 
 ### Docker Deployment
 
-Run the app in a Docker container:
+#### Local Development
+Run the app in a Docker container for local development:
 
 ```bash
 docker-compose up --build
@@ -104,6 +105,16 @@ docker-compose up --build
 Access on `http://localhost:3000` or from any device on your network using your machine's IP address.
 
 Database persists in `./data/storynexus.db` (mounted volume).
+
+#### Production Deployment from Docker Hub
+For production deployments on third-party servers, see [DEPLOYMENT.md](DEPLOYMENT.md) for complete CI/CD setup and deployment instructions.
+
+Quick deployment steps:
+1. Copy `docker-compose.deploy.yml` and `.env.deploy.example` to server
+2. Configure `.env` with your Docker Hub username
+3. Run: `docker compose -f docker-compose.deploy.yml up -d`
+
+Images are automatically built and pushed to Docker Hub via GitHub Actions on every push to `main` or version tag.
 
 ## Screenshots
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,19 @@
+services:
+  storynexus:
+    image: ${DOCKERHUB_USERNAME}/storynexus:latest
+    container_name: storynexus-app
+    ports:
+      - "${PORT:-3000}:3000"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DATABASE_PATH=/app/data/storynexus.db
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s


### PR DESCRIPTION
Implements production CI/CD workflow with GitHub Actions to build and publish Docker images to Docker Hub, plus separate deployment configuration for third-party servers.

Changes:
- GitHub Actions workflow for automated Docker builds and pushes
- Multi-architecture support (amd64, arm64)
- Deployment-specific docker-compose pulling pre-built images
- Comprehensive deployment documentation
- Enhanced .dockerignore for optimised builds
- Environment template for deployment configuration